### PR TITLE
Fix CNF converter to keep terminal rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,11 @@ def convert_to_cnf(g, start):
 
     for A,P in g.items():
         for p in P:
-            wrapped = [s if s in g or s=='ε' else T(s) for s in p]
+            if len(p) == 1:
+                # single terminals already satisfy CNF
+                wrapped = p
+            else:
+                wrapped = [s if s in g or s=='ε' else T(s) for s in p]
             new[A].append(wrapped)
     for t,v in term_map.items():
         new[v].append([t])


### PR DESCRIPTION
## Summary
- fix Python CNF conversion so single-terminal productions remain untouched

## Testing
- `python3 - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_686b39da18988331ab799773eb95518f