### PR TITLE
Fix CNF start symbol logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,8 +207,19 @@ def cfg_to_cnf(text):
     def step(lbl):
         log.append((lbl, format_grammar(G)))
 
-    if any(S in p for P in G.values() for p in P):
-        G = {**{"S0": [[S]]}, **G}
+    start_rhs = any(S in p for P in G.values() for p in P)
+    nullable = {A for A, P in G.items() if ['ε'] in P}
+    changed = True
+    while changed:
+        changed = False
+        for A, P in G.items():
+            if A in nullable:
+                continue
+            if any(all(s in nullable for s in q) for q in P):
+                nullable.add(A); changed = True
+    if start_rhs or S in nullable:
+        rule = [[S]] + ([['ε']] if S in nullable else [])
+        G = {**{"S0": rule}, **G}
         S = "S0"
         step("Add new start symbol")
     else:


### PR DESCRIPTION
## Summary
- calculate nullable symbols and detect if the start symbol is nullable
- add the new start rule when the original start is on the RHS or nullable

## Testing
- `python3 - <<'PY' ...` quick test of `cfg_to_cnf` with provided grammar

------
https://chatgpt.com/codex/tasks/task_e_686b6bbd6bc0833195e448fc95f8b7ab