### PR TITLE
Fix ε-removal logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,10 +122,12 @@ def remove_null_productions(g, start):
             for mask in range(1 << len(pos)):
                 q = [s for i,s in enumerate(p)
                        if not (i in pos and (mask >> pos.index(i)) & 1)]
-                if not q and A != start:
+                if not q:
+                    if A == start and ['ε'] not in new[A]:
+                        new[A].append(['ε'])
                     continue
                 if q not in new[A]:
-                    new[A].append(q or ['ε'])
+                    new[A].append(q)
     return dict(new)
 
 # ─── unit-removal ───────────────────────────────────────
@@ -266,7 +268,11 @@ def cfg_to_cnf(text):
         step("Add new start symbol")
     else:
         step("Original CFG")
-    G = remove_null_productions(G, S);     step("ε-removed")
+    G = remove_null_productions(G, S)
+    for A in list(G):
+        if A != S and ['ε'] in G[A]:
+            G[A] = [p for p in G[A] if p != ['ε']]
+    step("ε-removed")
     G = remove_unit_productions(G);        step("unit-removed")
     G = remove_useless_symbols(G, S);      step("useless-removed")
     G = convert_to_cnf(G, S)


### PR DESCRIPTION
## Summary
- adjust ε-removal to keep ε only for the start symbol
- defensively remove stray ε after null-production removal

## Testing
- `python3 - <<'EOF' ... EOF`

------
https://chatgpt.com/codex/tasks/task_e_686b91a0a7008331b3579777fd0dda75