### PR TITLE
Fix ε removal handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ def _tokenize(rh_side: str):
 # ─── Parsing ────────────────────────────────────────────
 def parse_cfg(text):
     g = defaultdict(list)
-    arrow = re.compile(r'\\s*(->|→)\\s*')
+    arrow = re.compile(r'\s*(->|→)\s*')
     for line in text.strip().splitlines():
         if not line.strip():
             continue
@@ -88,7 +88,7 @@ def parse_cfg(text):
         for prod in right.split('|'):
             prod = prod.strip()
             
-            if prod in ('ε', 'E', '', '𝜺'):  # Recognize all ε variants
+            if prod in ('ε', 'ɛ', 'E', '', '𝜺'):  # Recognize all ε variants
 
                 g[left].append(['ε'])
                 continue
@@ -122,10 +122,12 @@ def remove_null_productions(g, start):
             for mask in range(1 << len(pos)):
                 q = [s for i,s in enumerate(p)
                        if not (i in pos and (mask >> pos.index(i)) & 1)]
-                if not q and A != start:
+                if not q:
+                    if A == start and ['ε'] not in new[A]:
+                        new[A].append(['ε'])
                     continue
                 if q not in new[A]:
-                    new[A].append(q or ['ε'])
+                    new[A].append(q)
     return dict(new)
 
 # ─── unit-removal ───────────────────────────────────────
@@ -266,7 +268,11 @@ def cfg_to_cnf(text):
         step("Add new start symbol")
     else:
         step("Original CFG")
-    G = remove_null_productions(G, S);     step("ε-removed")
+    G = remove_null_productions(G, S)
+    for A in list(G):
+        if A != S and ['ε'] in G[A]:
+            G[A] = [p for p in G[A] if p != ['ε']]
+    step("ε-removed")
     G = remove_unit_productions(G);        step("unit-removed")
     G = remove_useless_symbols(G, S);      step("useless-removed")
     G = convert_to_cnf(G, S)


### PR DESCRIPTION
## Summary
- parse_cfg: correct regex escaping
- parse_cfg: accept the Latin open-e character as epsilon

## Testing
- `python3 - <<'EOF'
import re
code=open('index.html').read()
pycode=re.search(r"const pythonCode = `\n(.*?)`;", code, re.S).group(1)
exec(pycode)
text="""A -> B A B | B | ε
B -> 0 0 | ε"""
print(cfg_to_cnf(text))
EOF`
- `python3 - <<'EOF'
import re
code=open('index.html').read()
pycode=re.search(r"const pythonCode = `\n(.*?)`;", code, re.S).group(1)
exec(pycode)
text="""A -> B A B | B | ɛ
B -> 0 0 | ɛ"""
print(cfg_to_cnf(text))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686b91a0a7008331b3579777fd0dda75