### PR TITLE
Restore example CFG lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,8 @@
 <body>
   <h1>Context Free Grammar → Chomsky Normal Form (Reduction)</h1>
   <textarea id="src" rows="6">S -> ASA | aB
+A -> B | S
+B -> b | ε
 </textarea><br>
   <button id="run">Convert to CNF</button>
   <button id="gen">Generate Words</button>


### PR DESCRIPTION
## Summary
- bring back example grammar lines that were accidentally removed

## Testing
- `xmllint --noout index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbc7a4e248331b75cd45415199d6a