### PR TITLE
Add description field for grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Normal Form (CNF) directly in your browser. It runs entirely offline using
 2. **Open `index.html`** in any modern web browser.
 3. A page titled *"Con. Free Grammar → Chomsky Normal Form"* will appear.
 
-Paste your grammar, hit **Convert to CNF**, and the page will display the
+Paste your grammar and optionally jot down a short description of the
+language it generates. Hit **Convert to CNF**, and the page will display the
 transformed grammar along with each conversion stage. You can also click
 **Generate Words** to produce a few sample words from your grammar.
 

--- a/index.html
+++ b/index.html
@@ -53,23 +53,26 @@ B → b | ε
 </textarea><br>
   <button id="run">Convert to CNF</button>
 
-  <h2>2. CNF Conversion</h2>
+  <h2>2. Describe the Language</h2>
+  <textarea id="grammar-desc" rows="3" placeholder="e.g., { w | w starts and ends with the same symbol }"></textarea>
+
+  <h2>3. CNF Conversion</h2>
   <pre id="out"></pre>
 
-  <h2>3. Regular Expression</h2>
+  <h2>4. Regular Expression</h2>
   <pre id="regex"></pre>
 
-  <h2>4. Generate Words</h2>
+  <h2>5. Generate Words</h2>
   <button id="gen">Generate Words</button>
   <pre id="words"></pre>
 
-  <h2>5. Guess a Word</h2>
+  <h2>6. Guess a Word</h2>
   <label for="guess">Guess a word:</label>
   <input id="guess" type="text" />
   <button id="check">Check</button>
   <span id="guess-result"></span>
 
-  <h2>6. Word Progression</h2>
+  <h2>7. Word Progression</h2>
   <div id="progression-list"></div>
 <script type="module">
 /* ========== 1 ▸ spin-up Python in the browser ========== */


### PR DESCRIPTION
## Summary
- add a simple text area so users can describe their grammar
- mention the new description section in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e11d85f148331a38593dbd14815d1